### PR TITLE
Allow for provision of a Testcontainer instance

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,8 @@
   :dependencies [[org.clojure/clojure "1.10.1"]
                  [org.testcontainers/testcontainers "1.14.3"]]
   :plugins [[metosin/bat-test "0.4.4"]]
-  :bat-test {:report [:pretty {:type :junit 
+  :bat-test {:report [:pretty {:type :junit
                                :output-to "target/junit.xml"}]}
+  :profiles {:dev {:dependencies [[org.testcontainers/postgresql "1.14.3"]]}}
   :target-path "target/%s")
 

--- a/src/clj_test_containers/core.clj
+++ b/src/clj_test_containers/core.clj
@@ -11,23 +11,27 @@
     BindMode/READ_WRITE
     BindMode/READ_ONLY))
 
-(defn create
+(defn init
   "Sets the properties for a testcontainer instance"
-  [{:keys [container image-name exposed-ports env-vars command]}]
-  (let [container (or container (GenericContainer. image-name))]
-    (.setExposedPorts container (map int exposed-ports))
+  [{:keys [container exposed-ports env-vars command]}]
+  (.setExposedPorts container (map int exposed-ports))
 
-    (if (some? env-vars)
-      (doseq [pair env-vars]
-        (.addEnv container (first pair) (second pair))))
+  (when (some? env-vars)
+    (doseq [pair env-vars]
+      (.addEnv container (first pair) (second pair))))
 
-    (if (some? command)
-      (.setCommand container command))
+  (when (some? command)
+    (.setCommand container command))
 
-    {:container container
-     :exposed-ports (.getExposedPorts container)
-     :env-vars (.getEnvMap container)
-     :host (.getHost container)}))
+  {:container container
+   :exposed-ports (.getExposedPorts container)
+   :env-vars (.getEnvMap container)
+   :host (.getHost container)})
+
+(defn create
+  "Creates a generic testcontainer and sets its properties"
+  [{:keys [image-name] :as options}]
+  (init (assoc options :container (GenericContainer. image-name))))
 
 (defn map-classpath-resource!
   "Maps a resource in the classpath to the given container path. Should be called before starting the container!"

--- a/src/clj_test_containers/core.clj
+++ b/src/clj_test_containers/core.clj
@@ -16,22 +16,22 @@
   [{:keys [container exposed-ports env-vars command]}]
   (.setExposedPorts container (map int exposed-ports))
 
-  (when (some? env-vars)
-    (doseq [pair env-vars]
-      (.addEnv container (first pair) (second pair))))
+  (run! (fn [[k v]] (.addEnv container k v)) env-vars)
 
-  (when (some? command)
+  (when command
     (.setCommand container command))
 
   {:container container
-   :exposed-ports (.getExposedPorts container)
-   :env-vars (.getEnvMap container)
+   :exposed-ports (vec (.getExposedPorts container))
+   :env-vars (into {} (.getEnvMap container))
    :host (.getHost container)})
 
 (defn create
   "Creates a generic testcontainer and sets its properties"
   [{:keys [image-name] :as options}]
-  (init (assoc options :container (GenericContainer. image-name))))
+  (->> (GenericContainer. image-name)
+       (assoc options :container)
+       init))
 
 (defn map-classpath-resource!
   "Maps a resource in the classpath to the given container path. Should be called before starting the container!"

--- a/src/clj_test_containers/core.clj
+++ b/src/clj_test_containers/core.clj
@@ -13,8 +13,8 @@
 
 (defn create
   "Sets the properties for a testcontainer instance"
-  [{:keys [image-name exposed-ports env-vars command]}]
-  (let [container (GenericContainer. image-name)]
+  [{:keys [container image-name exposed-ports env-vars command]}]
+  (let [container (or container (GenericContainer. image-name))]
     (.setExposedPorts container (map int exposed-ports))
 
     (if (some? env-vars)

--- a/test/clj_test_containers/core_test.clj
+++ b/test/clj_test_containers/core_test.clj
@@ -1,6 +1,8 @@
 (ns clj-test-containers.core-test
   (:require [clojure.test :refer :all]
-            [clj-test-containers.core :refer :all]))
+            [clj-test-containers.core :refer :all])
+  (:import [org.testcontainers.containers
+            PostgreSQLContainer]))
 
 (deftest init-test
   (testing "Testing basic testcontainer generic image initialisation"
@@ -19,7 +21,17 @@
 
   (testing "Executing a command in the running Docker container"
     (let [container (create {:image-name "postgres:12.2"
-                             :exposed-ports [5432] 
+                             :exposed-ports [5432]
+                             :env-vars {"POSTGRES_PASSWORD" "pw"}})
+          initialized-container (start! container)
+          result (execute-command! initialized-container ["whoami"])
+          stopped-container (stop! container)]
+      (is (= 0 (:exit-code result)))
+      (is (= "root\n" (:stdout result)))))
+
+  (testing "Executing a command in the running Docker container with a custom container"
+    (let [container (create {:container (PostgreSQLContainer. "postgres:12.2")
+                             :exposed-ports [5432]
                              :env-vars {"POSTGRES_PASSWORD" "pw"}})
           initialized-container (start! container)
           result (execute-command! initialized-container ["whoami"])

--- a/test/clj_test_containers/core_test.clj
+++ b/test/clj_test_containers/core_test.clj
@@ -4,7 +4,7 @@
   (:import [org.testcontainers.containers
             PostgreSQLContainer]))
 
-(deftest init-test
+(deftest create-test
   (testing "Testing basic testcontainer generic image initialisation"
     (let [container (create {:image-name "postgres:12.2"
                              :exposed-ports [5432] 
@@ -30,9 +30,9 @@
       (is (= "root\n" (:stdout result)))))
 
   (testing "Executing a command in the running Docker container with a custom container"
-    (let [container (create {:container (PostgreSQLContainer. "postgres:12.2")
-                             :exposed-ports [5432]
-                             :env-vars {"POSTGRES_PASSWORD" "pw"}})
+    (let [container (init {:container (PostgreSQLContainer. "postgres:12.2")
+                           :exposed-ports [5432]
+                           :env-vars {"POSTGRES_PASSWORD" "pw"}})
           initialized-container (start! container)
           result (execute-command! initialized-container ["whoami"])
           stopped-container (stop! container)]


### PR DESCRIPTION
Testcontainers provides many different container implementations that
can be very useful. This simple change allows callers to provide their
own, premade container instance so consumers can flexibly choose their
container type. If no container instance is supplied, then
clj-test-containers falls back to its original behavior.