### PR TITLE
Use kaocha instead of bat-test, enable generative fdef checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
           key: v1-dependencies-{{ checksum "project.clj" }}
 
       # run tests!
-      - run: lein bat-test cloverage
+      - run: lein test
 
       - store_test_results:
           path: target

--- a/project.clj
+++ b/project.clj
@@ -1,14 +1,20 @@
 (defproject clj-test-containers "0.2.0-SNAPSHOT"
   :description "A lightweight, unofficial wrapper around the Testcontainers Java library"
+
   :url "https://github.com/javahippie/clj-test-containers"
+
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
 
   :dependencies [[org.clojure/clojure "1.10.1"]
                  [org.testcontainers/testcontainers "1.14.3"]]
-  :plugins [[metosin/bat-test "0.4.4"]]
-  :bat-test {:report [:pretty {:type :junit
-                               :output-to "target/junit.xml"}]}
-  :profiles {:dev {:dependencies [[org.testcontainers/postgresql "1.14.3"]]}}
+
+  :aliases {"test" ["run" "-m" "kaocha.runner"]}
+
+  :profiles {:dev {:dependencies [[org.testcontainers/postgresql "1.14.3"]
+                                  [lambdaisland/kaocha-cloverage "1.0-45"]
+                                  [lambdaisland/kaocha "1.0.641"]
+                                  [lambdaisland/kaocha-junit-xml "0.0.76"]]}}
+
   :target-path "target/%s")
 

--- a/src/clj_test_containers/core.clj
+++ b/src/clj_test_containers/core.clj
@@ -1,10 +1,10 @@
 (ns clj-test-containers.core
-  (:require [clojure.java.io :as io])
+  (:require [clojure.spec.alpha :as s])
   (:import [org.testcontainers.containers GenericContainer]
            [org.testcontainers.utility MountableFile]
            [org.testcontainers.containers BindMode Network]
            [org.testcontainers.images.builder ImageFromDockerfile]
-           [java.nio.file Path Paths]))
+           [java.nio.file Paths]))
 
 (defn- resolve-bind-mode
   [bind-mode]

--- a/tests.edn
+++ b/tests.edn
@@ -1,0 +1,5 @@
+#kaocha/v1
+{:plugins [:kaocha.plugin/junit-xml
+           :kaocha.plugin/cloverage
+           :kaocha.plugin.alpha/spec-test-check]
+ :kaocha.plugin.junit-xml/target-file "target/junit.xml"}


### PR DESCRIPTION
I'd like to write some [specs](https://clojure.org/guides/spec) for the inputs and outputs of this library's public interface. [kaocha](https://github.com/lambdaisland/kaocha) is a very flexible test runner that includes support for or has plugins that support generative spec tests, Cloverage, and JUnit output. This change switches from bat-test to kaocha and configures it with the aforementioned capabilities.