### PR TITLE
Rename init-network, remove .getId call

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Creates a testcontainers instance from a given Docker label and returns them
 | `:exposed-ports` 	 | Vector with ints, mandatory  | All ports which should be exposed and mapped to a local port |
 | `:env-vars` 		 | Map      			| A map with environment variables|
 | `:command`  		 | Vector with strings     | The start command of the container|
-| `:network`			 |	Map					| A map containing the configuration of a Docker Network (see: `init-network`)|
+| `:network`			 |	Map					| A map containing the configuration of a Docker Network (see: `create-network`)|
 | `:network-aliases` | Map					| A list of alias names for the container on the network |
 
 #### Result: 
@@ -87,7 +87,7 @@ Creates a testcontainers instance from a given Docker label and returns them
 (create {:image-name "alpine:3.2"
          :exposed-ports [80]
          :env-vars {"MAGIC_NUMBER" "42"}
-         :network (init-network)
+         :network (create-network)
          :network-aliases ["api-server"]
          :command ["/bin/sh" 
                    "-c" 
@@ -105,7 +105,7 @@ Initializes a given Testcontainer, which was e.g. provided by a library
 | `:exposed-ports` 	| Vector with ints, mandatory  | All ports which should be exposed and mapped to a local port |
 | `:env-vars` 		| Map      			| A map with environment variables|
 | `:command`  		| Vector with strings     | The start command of the container|
-| `:network`			| Map						| A map containing the configuration of a Docker Network (see: `init-network`)|
+| `:network`			| Map						| A map containing the configuration of a Docker Network (see: `create-network`)|
 | `:network-aliases` | Map					| A list of alias names for the container on the network |
 #### Result: 
 
@@ -140,7 +140,7 @@ Creates a testcontainer from a Dockerfile
 | `:exposed-ports` 	| Vector with ints, mandatory  | All ports which should be exposed and mapped to a local port |
 | `:env-vars` 		| Map      			| A map with environment variables|
 | `:command`  		| Vector with strings     | The start command of the container|
-| `:network`			| Map						| A map containing the configuration of a Docker Network (see: `init-network`)|
+| `:network`			| Map						| A map containing the configuration of a Docker Network (see: `create-network`)|
 | `:network-aliases` | Map					| A list of alias names for the container on the network |
 #### Result: 
 
@@ -339,7 +339,7 @@ Executes a command in the running container, and returns the result
 (execute-command! container ["tail" "/opt/test.sql"])
 ```
 
-### init-network
+### create-network
 Creates a network. The optional map accepts config values for enabling ipv6 and setting the driver
 
 
@@ -356,7 +356,6 @@ Creates a network. The optional map accepts config values for enabling ipv6 and 
 | Key      			| Type          		| Description  |
 | ------------- 		|:-------------		| :-----|
 | `:network`		| `org.testcontainers.containers.Network` 	 				| The instance of the network |
-| `:id`			| String 				| The identifier of the network |
 | `:name`			| String 				| The name of the network |
 | `:ipv6`			| boolean 				| Does the network enable IPv6? |
 | `:driver`			| String 				| The network driver used |
@@ -365,11 +364,11 @@ Creates a network. The optional map accepts config values for enabling ipv6 and 
 
 ```clojure
 ;;Create with config
-(init-network {:ipv6 false
+(create-network {:ipv6 false
                :driver "overlay")
 
 ;;Create with default config               
-(init-network)   
+(create-network)   
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ Creates a network. The optional map accepts config values for enabling ipv6 and 
 ```clojure
 ;;Create with config
 (create-network {:ipv6 false
-               :driver "overlay")
+                 :driver "overlay")
 
 ;;Create with default config               
 (create-network)   

--- a/src/clj_test_containers/core.clj
+++ b/src/clj_test_containers/core.clj
@@ -132,16 +132,16 @@
       (dissoc :id)
       (dissoc :mapped-ports)))
 
-(s/fdef init-network
+(s/fdef create-network
         :args (s/alt :nullary (s/cat)
-                     :unary (s/cat :init-network-options
-                                   ::cs/init-network-options))
+                     :unary (s/cat :create-network-options
+                                   ::cs/create-network-options))
         :ret ::cs/network)
 
-(defn ^:no-gen init-network
+(defn create-network
   "Creates a network. The optional map accepts config values for enabling ipv6 and setting the driver"
   ([]
-   (init-network {}))
+   (create-network {}))
   ([{:keys [ipv6 driver]}]
    (let [builder (Network/builder)]
      (when ipv6
@@ -152,7 +152,10 @@
 
      (let [network (.build builder)]
        {:network network
-        :id (.getId network)
         :name (.getName network)
         :ipv6 (.getEnableIpv6 network)
         :driver (.getDriver network)}))))
+
+(defn ^:deprecated init-network
+  [& args]
+  (apply create-network args))

--- a/src/clj_test_containers/core.clj
+++ b/src/clj_test_containers/core.clj
@@ -156,6 +156,4 @@
         :ipv6 (.getEnableIpv6 network)
         :driver (.getDriver network)}))))
 
-(defn ^:deprecated init-network
-  [& args]
-  (apply create-network args))
+(def ^:deprecated init-network create-network)

--- a/src/clj_test_containers/spec/core.clj
+++ b/src/clj_test_containers/spec/core.clj
@@ -6,7 +6,6 @@
 
 (s/def ::network
   (s/nilable (s/keys :req-un [::csn/network
-                              ::csn/id
                               ::csn/name
                               ::csn/ipv6
                               ::csn/driver])))
@@ -34,6 +33,6 @@
                    ::network
                    ::csc/network-aliases]))
 
-(s/def ::init-network-options
+(s/def ::create-network-options
   (s/keys :opt-un [::csn/ipv6
                    ::csn/driver]))

--- a/test/clj_test_containers/core_test.clj
+++ b/test/clj_test_containers/core_test.clj
@@ -123,7 +123,7 @@
 
 (deftest networking-test
   (testing "Putting two containers into the same network and check their communication"
-    (let [network (sut/init-network)
+    (let [network (sut/create-network)
           server-container (sut/create {:image-name "alpine:3.5"
                                         :network network
                                         :network-aliases ["foo"]


### PR DESCRIPTION
* Should be called `create-network` to match the existing `create` function
* Network#getId oddly has a side effect, which made generative testing more difficult. Removing this defers network creation until `start!` is called
* Mark init-network as deprecated

Resolves #29 