### PR TITLE
Use .copyFileToContainer when the container is already started

### DIFF
--- a/.cljstyle
+++ b/.cljstyle
@@ -1,3 +1,5 @@
-{:file-pattern #"\.(clj[sc]?|edn|cljstyle)$"
- :list-indent-size 1
- :padding-lines 1}
+{:files {:pattern #"\.(clj[sc]?|edn|cljstyle)$"},
+ :rules
+ {:indentation {:list-indent 1},
+  :blank-lines {:padding-lines 1},
+  :namespaces {:indent-size 1}}}

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ pom.xml.asc
 .hg/
 .DS_Store
 .lsp
+.cpcache

--- a/project.clj
+++ b/project.clj
@@ -19,7 +19,7 @@
                                   [lambdaisland/kaocha-cloverage "1.0-45"]
                                   [lambdaisland/kaocha-junit-xml "0.0.76"]
                                   [lambdaisland/kaocha-junit-xml "0.0.76"]
-                                  [mvxcvi/cljstyle "0.13.0" :exclusions [org.clojure/clojure]]
+                                  [mvxcvi/cljstyle "0.14.0" :exclusions [org.clojure/clojure]]
                                   [org.clojure/test.check "1.1.0"]
                                   [org.clojure/tools.namespace "1.0.0"]
                                   [org.testcontainers/postgresql "1.15.0-rc2"]]

--- a/src/clj_test_containers/core.clj
+++ b/src/clj_test_containers/core.clj
@@ -195,18 +195,24 @@
                               (resolve-bind-mode mode))))
 
 (defn copy-file-to-container!
-  "Copies a file into the running container"
-  [{:keys [^GenericContainer container] :as container-config}
+  "If a container is not yet started, adds a mapping from mountable file to
+  container path that will be copied to the container on startup. If the
+  container is already running, copy the file to the running container."
+  [{:keys [^GenericContainer container id] :as container-config}
    {:keys [^String container-path ^String path type]}]
   (let [^MountableFile mountable-file
         (case type
           :classpath-resource (MountableFile/forClasspathResource path)
           :host-path          (MountableFile/forHostPath path))]
-    (assoc container-config
-           :container
-           (.withCopyFileToContainer container
-                                     mountable-file
-                                     container-path))))
+    (if id
+      (do
+        (.copyFileToContainer container mountable-file container-path)
+        container-config)
+      (assoc container-config
+             :container
+             (.withCopyFileToContainer container
+                                       mountable-file
+                                       container-path)))))
 
 (defn execute-command!
   "Executes a command in the container, and returns the result"


### PR DESCRIPTION
Currently, if `copy-file-to-container!` is called on an already-running container, the file is not copied, because `copy-file-to-container!` only updates the mapping of files to be copied on startup. This change checks if the container config contains an ID, and if it does, it calls `.copyFileToContainer` instead of `.withCopyFileToContainer`.