### PR TITLE
Fix container path parameter for `copy-file-to-container!` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ Copies a file from your filesystem or classpath into the running container
 | `container-config`| Map, mandatory | Return value of the `create` function |
 | Second parameter: | | |
 | `:path`            | String, mandatory | Path to a classpath resource *or* file on your filesystem |
-| `:host-path`        | String, mandatory                | Path, to which the file should be copied |
+| `:container-path`        | String, mandatory                | Path, to which the file should be copied |
 | `:type`            | Keyword, mandatory                | `:classpath-resource` or `:host-path` |
 
 #### Result:


### PR DESCRIPTION
Hey there! I have been experimenting with this project and kept running into a `NullPointerException` when using `:host-path` as a parameter. Eventually, by reading the `clj-test-containers` and `testcontainers-java` code I realized that the parameter should actually be `:container-path`.

https://github.com/javahippie/clj-test-containers/blob/25d1ba491b79211b5ca67363ea3b2553e3634e7d/src/clj_test_containers/core.clj#L258-L276

The example code is correct,

```clojure
(copy-file-to-container! container {:path           "test.sql"
                                    :container-path "/opt/test.sql"
                                    :type           :host-path})
```

but I was thrown off by the defined config parameters.