### PR TITLE
create-network: Fix network leak by setting the proper network :id

### DIFF
--- a/src/clj_test_containers/core.clj
+++ b/src/clj_test_containers/core.clj
@@ -386,9 +386,11 @@
        (.driver builder driver))
 
      (let [network (.build builder)
-           network-name (.getName network)]
-       (swap! started-instances conj {:type :network :id :network-name})
-       {:network network
+           network-name (.getName network)
+           network-id (.getId network)]
+       (swap! started-instances conj {:type :network :id network-id})
+       {:id network-id
+        :network network
         :name    network-name
         :ipv6    (.getEnableIpv6 network)
         :driver  (.getDriver network)}))))


### PR DESCRIPTION
There was a bug in create/remove-network! due to the ID being incorrectly saved as :network-name.