### PR TITLE
with-network: Network test fixture function

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,25 @@ Creates a network. The optional map accepts config values for enabling ipv6 and 
 (create-network)
 ```
 
+### with-network
+
+Create and bind a network to *network* and run `test-fn`. The network is removed after the function executes.
+
+#### Config parameters:
+
+`with-network` takes an optional map of options, equivalent to `create-network`.
+
+
+#### Example:
+
+```clojure
+;; Run tests within an ephemeral network
+(use-fixtures :once (tc/with-network {:ipv6? true}))
+
+(deftest test-network-loaded
+  (is (some? tc/*network*)))
+```
+
 ### perform-cleanup!
 
 Stops and removes all containers which were created in the JVM, including the REPL session you are in. This is helpful,

--- a/src/clj_test_containers/core.clj
+++ b/src/clj_test_containers/core.clj
@@ -30,6 +30,8 @@
      BindMode/READ_WRITE
      BindMode/READ_ONLY)))
 
+(def ^:dynamic *network* nil)
+
 (defonce started-instances (atom #{}))
 
 (defmulti wait
@@ -401,6 +403,16 @@
       (.removeNetworkCmd (:id instance))
       (.exec))
   instance)
+
+(defn with-network
+  ([] (with-network {}))
+  ([network-options]
+   (fn [test-fn]
+     (binding [*network* (create-network network-options)]
+       (try
+         (test-fn)
+         (finally
+           (remove-network! *network*)))))))
 
 (defn- stop-and-remove-container! [instance]
   (let [docker-client (DockerClientFactory/instance)]


### PR DESCRIPTION
`with-network` provides a test fixture function which will set up and tear down a network for a test suite.