### PR TITLE
container: :host networking mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Creates a testcontainers instance from a given Docker label and returns them
 | `:exposed-ports`   | Vector with ints, mandatory | All ports which should be exposed and mapped to a local port                                        |
 | `:env-vars`        | Map                         | A map with environment variables                                                                    |
 | `:command`         | Vector with strings         | The start command of the container                                                                  |
-| `:network`         | Map                         | A map containing the configuration of a Docker Network (see: `create-network`)                      |
+| `:network`         | Map                         | A map containing the configuration of a Docker Network (see: `create-network`). For host networking, use :host |
 | `:network-aliases` | Map                         | A list of alias names for the container on the network                                              |
 | `:wait-for`        | Map                         | A map containing the [wait strategy](doc/wait-strategies.md) to use and the condition to check for |
 | `:log-to`          | Map                         | A map containing the [log strategy](doc/log-strategies.md) to use, e.g. {:log-strategy string}     |
@@ -129,10 +129,10 @@ Initializes a given Testcontainer, which was e.g. provided by a library
 | `:exposed-ports`   | Vector with ints, mandatory                                 | All ports which should be exposed and mapped to a local port                                        |
 | `:env-vars`        | Map                                                         | A map with environment variables                                                                    |
 | `:command`         | Vector with strings                                         | The start command of the container                                                                  |
-| `:network`         | Map                                                         | A map containing the configuration of a Docker Network (see: `create-network`)                      |
+| `:network`         | Map or :host                                                | A map containing the configuration of a Docker Network (see: `create-network`). For host networking, use :host |
 | `:network-aliases` | Map                                                         | A list of alias names for the container on the network                                              |
-| `:wait-for`        | Map                                                         | A map containing the [wait strategy](doc/wait-strategies.md) to use and the condition to check for |
-| `:log-to`          | Map                                                         | A map containing the [log strategy](doc/log-strategies.md) to use, e.g. {:log-strategy string}                               |
+| `:wait-for`        | Map                                                         | A map containing the [wait strategy](doc/wait-strategies.md) to use and the condition to check for  |
+| `:log-to`          | Map                                                         | A map containing the [log strategy](doc/log-strategies.md) to use, e.g. {:log-strategy string}      |
 |                    |                                                             |                                                                                                     |
 
 #### Result:
@@ -143,7 +143,7 @@ Initializes a given Testcontainer, which was e.g. provided by a library
 | `:exposed-ports` | Vector with ints                          | Value of the same input parameter                                                         |
 | `:env-vars`      | Map                                       | Value of the same input parameter                                                         |
 | `:host`          | String                                    | The host for the Docker Container                                                         |
-| `:network`       | Map                                       | The network configuration of the Container, if provided                                   |
+| `:network`       | Map or :host                              | The network configuration of the Container, if provided.                                  |
 | `:wait-for`      | Map                                       | The wait-for configuration of the Container, if provided!                                 |
 
 #### Example:
@@ -183,7 +183,7 @@ Creates a testcontainer from a Dockerfile
 | `:exposed-ports`   | Vector with ints, mandatory | All ports which should be exposed and mapped to a local port                   |
 | `:env-vars`        | Map                         | A map with environment variables                                               |
 | `:command`         | Vector with strings         | The start command of the container                                             |
-| `:network`         | Map                         | A map containing the configuration of a Docker Network (see: `create-network`) |
+| `:network`         | Map                         | A map containing the configuration of a Docker Network (see: `create-network`). For host networking, use :host |
 | `:network-aliases` | Map                         | A list of alias names for the container on the network                         |
 | `:wait-for`        | Map                         | A map containing the [wait strategy](doc/wait-strategies.md) to use and the condition to check for       |
 | `:log-to`          | Map                         | A map containing the [log strategy](doc/log-strategies.md) to use, e.g. {:log-strategy string}          |
@@ -399,7 +399,7 @@ Creates a network. The optional map accepts config values for enabling ipv6 and 
 | Key           | Type           | Description                                                |
 | ------------- | :------------- | :-----                                                     |
 | `:ipv6`       | boolean        | Should the network enable IPv6?                            |
-| `:driver`     | String         | The network driver used by Docker, e.g. `bridge` or `host` |
+| `:driver`     | String         | The network driver used by Docker, e.g. `bridge` |
 
 #### Result:
 

--- a/src/clj_test_containers/core.clj
+++ b/src/clj_test_containers/core.clj
@@ -198,7 +198,9 @@
     (.setCommand container ^"[Ljava.lang.String;" (into-array String command)))
 
   (when network
-    (.setNetwork container (:network network)))
+    (if (= :host network)
+      (.withNetworkMode container "host")
+      (.setNetwork container (:network network))))
 
   (when network-aliases
     (.setNetworkAliases container network-aliases))


### PR DESCRIPTION
Host networking is unique from the other network drivers. It requires the container to run (.withNetworkMode "host"). Trying to create a docker network with the "host" driver does not work.

This adds a special keyword `:host` which may be set as the container `:network`.