### PR TITLE
container: Add `:startup` strategy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Creates a testcontainers instance from a given Docker label and returns them
 | `:command`         | Vector with strings         | The start command of the container                                                                  |
 | `:network`         | Map                         | A map containing the configuration of a Docker Network (see: `create-network`)                      |
 | `:network-aliases` | Map                         | A list of alias names for the container on the network                                              |
+| `:startup`         | Map                         | A map containing the [startup strategy](doc/startup-strategies.md) to use                           |
 | `:wait-for`        | Map                         | A map containing the [wait strategy](doc/wait-strategies.md) to use and the condition to check for |
 | `:log-to`          | Map                         | A map containing the [log strategy](doc/log-strategies.md) to use, e.g. {:log-strategy string}     |
 
@@ -88,6 +89,7 @@ Creates a testcontainers instance from a given Docker label and returns them
 | `:env-vars`      | Map                                       | Value of the same input parameter                                                         |
 | `:host`          | String                                    | The host for the Docker Container                                                         |
 | `:network`       | Map                                       | The network configuration of the Container, if provided                                   |
+| `:startup`       | Map                                       | The startup configuration of the Container, if provided                                   |
 | `:wait-for`      | Map                                       | The wait-for configuration of the Container, if provided!                                 |
 
 #### Example:
@@ -131,8 +133,9 @@ Initializes a given Testcontainer, which was e.g. provided by a library
 | `:command`         | Vector with strings                                         | The start command of the container                                                                  |
 | `:network`         | Map                                                         | A map containing the configuration of a Docker Network (see: `create-network`)                      |
 | `:network-aliases` | Map                                                         | A list of alias names for the container on the network                                              |
-| `:wait-for`        | Map                                                         | A map containing the [wait strategy](doc/wait-strategies.md) to use and the condition to check for |
-| `:log-to`          | Map                                                         | A map containing the [log strategy](doc/log-strategies.md) to use, e.g. {:log-strategy string}                               |
+| `:startup`         | Map                                                         | A map containing the [startup strategy](doc/startup-strategies.md) to use                           |
+| `:wait-for`        | Map                                                         | A map containing the [wait strategy](doc/wait-strategies.md) to use and the condition to check for  |
+| `:log-to`          | Map                                                         | A map containing the [log strategy](doc/log-strategies.md) to use, e.g. {:log-strategy string}      |
 |                    |                                                             |                                                                                                     |
 
 #### Result:
@@ -144,6 +147,7 @@ Initializes a given Testcontainer, which was e.g. provided by a library
 | `:env-vars`      | Map                                       | Value of the same input parameter                                                         |
 | `:host`          | String                                    | The host for the Docker Container                                                         |
 | `:network`       | Map                                       | The network configuration of the Container, if provided                                   |
+| `:startup`       | Map                                       | The startup configuration of the Container, if provided                                   |
 | `:wait-for`      | Map                                       | The wait-for configuration of the Container, if provided!                                 |
 
 #### Example:
@@ -186,6 +190,7 @@ Creates a testcontainer from a Dockerfile
 | `:network`         | Map                         | A map containing the configuration of a Docker Network (see: `create-network`) |
 | `:network-aliases` | Map                         | A list of alias names for the container on the network                         |
 | `:wait-for`        | Map                         | A map containing the [wait strategy](doc/wait-strategies.md) to use and the condition to check for       |
+| `:startup`         | Map                         | A map containing the [startup strategy](doc/startup-strategies.md) to use                                |
 | `:log-to`          | Map                         | A map containing the [log strategy](doc/log-strategies.md) to use, e.g. {:log-strategy string}          |
 |                    |                             |                                                                                |
 
@@ -198,6 +203,7 @@ Creates a testcontainer from a Dockerfile
 | `:env-vars`      | Map                                       | Value of the same input parameter                                                         |
 | `:host`          | String                                    | The host for the Docker Container                                                         |
 | `:network`       | Map                                       | The network configuration of the Container, if provided                                   |
+| `:startup`       | Map                                       | The startup configuration of the Container, if provided                                   |
 | `:wait-for`      | Map                                       | The wait-for configuration of the Container, if provided!                                 |
 
 #### Example:

--- a/doc/startup-strategies.md
+++ b/doc/startup-strategies.md
@@ -1,0 +1,22 @@
+# Startup strategies
+
+Normally, test containers wait until the container has reached the running state before continuing with the test. In some scenarios, you may wish for a container to run to completion before proceeding with the test suite. This is what startup strategies are for.
+
+See also: [Startup check strategies](https://java.testcontainers.org/features/startup_and_waits/#startup-check-strategies)
+
+## Running Strategy (default)
+
+The `:running` strategy waits for the container to enter a running state.
+Example:
+
+```clojure
+{:startup {:strategy :running}}
+```
+
+## One-shot Strategy
+
+The `:one-shot` strategy waits for the container to run to completion with exit status 0.
+
+```clojure
+{:startup {:strategy :one-shot}}
+```

--- a/src/clj_test_containers/core.clj
+++ b/src/clj_test_containers/core.clj
@@ -17,6 +17,8 @@
       BaseConsumer
       OutputFrame
       ToStringConsumer)
+    (org.testcontainers.containers.startupcheck
+      OneShotStartupCheckStrategy)
     (org.testcontainers.containers.wait.strategy
       Wait)
     (org.testcontainers.images.builder
@@ -187,6 +189,7 @@
            command
            network
            network-aliases
+           startup
            wait-for] :as init-options}]
 
   (.setExposedPorts container (map int exposed-ports))
@@ -203,10 +206,20 @@
   (when network-aliases
     (.setNetworkAliases container network-aliases))
 
+  (when (some? startup)
+    (case (:strategy startup)
+      :one-shot
+      (.withStartupCheckStrategy container (OneShotStartupCheckStrategy.))
+
+      (:running nil)
+      ;; Default
+      nil))
+
   (merge init-options {:container     container
                        :exposed-ports (vec (.getExposedPorts container))
                        :env-vars      (into {} (.getEnvMap container))
                        :host          (.getHost container)
+                       :startup       startup
                        :network       network} (wait wait-for container)))
 
 (s/fdef create


### PR DESCRIPTION
Support [Startup Check
Strategies](https://java.testcontainers.org/features/startup_and_waits/#startup-check-strategies)

including OneShotStartupCheckStrategy.