### PR TITLE
Bump Dependencies Versions

### DIFF
--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -13,6 +13,10 @@ runs:
         path: ~/.m2/repository
         key: ${{ runner.os }}-lein-${{ hashFiles('**/project.clj') }}
         restore-keys: ${{ runner.os }}-lein-
+    - name: Install clojure tools
+      uses: DeLaGuardo/setup-clojure@13.1
+      with:
+        lein: 2.11.2
     - name: Clear existing docker image cache
       shell: bash
       run: docker image prune -af

--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Setup Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   release:
     name: Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/deps.edn
+++ b/deps.edn
@@ -18,7 +18,7 @@
                                        lambdaisland/kaocha-cloverage {:mvn/version "1.1.89"}
                                        lambdaisland/kaocha-junit-xml {:mvn/version "1.17.101"}
                                        org.clojure/test.check        {:mvn/version "1.1.1"}
-                                       orchestra                     {:mvn/version "2021.01.01-1"}
+                                       orchestra/orchestra           {:mvn/version "2021.01.01-1"}
                                        org.testcontainers/postgresql {:mvn/version "1.20.4"}}
                          :main-opts   ["-m" "kaocha.runner" "--reporter" "kaocha.report/documentation"]}
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:paths   ["src" "resources"]
 
- :deps    {org.clojure/clojure               {:mvn/version "1.10.3"}
-           org.testcontainers/testcontainers {:mvn/version "1.19.7"}}
+ :deps    {org.clojure/clojure               {:mvn/version "1.12.0"}
+           org.testcontainers/testcontainers {:mvn/version "1.20.4"}}
 
  :aliases {:dev         {:extra-paths "dev-src"}
            :test        {:extra-paths ["test" "test/resources"]
@@ -10,7 +10,7 @@
                                        lambdaisland/kaocha-cloverage {:mvn/version "1.1.89"}
                                        lambdaisland/kaocha-junit-xml {:mvn/version "1.17.101"}
                                        org.clojure/test.check        {:mvn/version "1.1.1"}
-                                       org.testcontainers/postgresql {:mvn/version "1.19.7"}}}
+                                       org.testcontainers/postgresql {:mvn/version "1.20.4"}}}
 
            :test-runner {:extra-paths ["test" "test/resources"]
                          :extra-deps  {expound/expound               {:mvn/version "0.9.0"}
@@ -19,7 +19,7 @@
                                        lambdaisland/kaocha-junit-xml {:mvn/version "1.17.101"}
                                        org.clojure/test.check        {:mvn/version "1.1.1"}
                                        orchestra                     {:mvn/version "2021.01.01-1"}
-                                       org.testcontainers/postgresql {:mvn/version "1.19.7"}}
+                                       org.testcontainers/postgresql {:mvn/version "1.20.4"}}
                          :main-opts   ["-m" "kaocha.runner" "--reporter" "kaocha.report/documentation"]}
 
            :cljstyle    {:extra-deps {mvxcvi/cljstyle {:mvn/version "0.16.630"

--- a/project.clj
+++ b/project.clj
@@ -6,8 +6,8 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
 
-  :dependencies [[org.clojure/clojure "1.10.3"]
-                 [org.testcontainers/testcontainers "1.19.7"]]
+  :dependencies [[org.clojure/clojure "1.12.0"]
+                 [org.testcontainers/testcontainers "1.20.4"]]
 
   :aliases {"test" ["run" "-m" "kaocha.runner"]
             "cljstyle" ["run" "-m" "cljstyle.main"]}
@@ -22,7 +22,7 @@
                                   [org.clojure/test.check "1.1.1"]
                                   [orchestra "2021.01.01-1"]
                                   [org.clojure/tools.namespace "1.5.0"]
-                                  [org.testcontainers/postgresql "1.19.7"]
+                                  [org.testcontainers/postgresql "1.20.4"]
                                   [com.fzakaria/slf4j-timbre "0.4.1"]
                                   [nrepl "1.0.0"]]
                    :source-paths ["dev-src"]}


### PR DESCRIPTION
I’ve recently started using the Kafka-native image in my tests. Since it was introduced in version 1.20.1 of Testcontainers, I had to fork this repository and update the dependency versions accordingly. It would be great if you could review and merge this PR to keep the dependencies up to date in the main repository.

Additionally, I had to make some changes to the GitHub Actions workflows because lein was missing. Please let me know if I’ve overlooked anything or if there are further changes required.